### PR TITLE
Adds handling Android USE_FULL_SCREEN_INTENT special permission

### DIFF
--- a/permission_handler_android/CHANGELOG.md
+++ b/permission_handler_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 12.0.14
+
+* Adds support for USE_FULL_SCREEN_INTENT permission check on Android 14+
+
 ## 12.0.13
 
 * Updates the Android min SDK to 19 (from 16).
@@ -21,7 +25,7 @@
 
 ## 12.0.8
 
-* Adds support for limited photo and video permission on Android. 
+* Adds support for limited photo and video permission on Android.
 
 ## 12.0.7
 

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionConstants.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionConstants.java
@@ -16,6 +16,7 @@ final class PermissionConstants {
     static final int PERMISSION_CODE_REQUEST_INSTALL_PACKAGES = 212;
     static final int PERMISSION_CODE_ACCESS_NOTIFICATION_POLICY = 213;
     static final int PERMISSION_CODE_SCHEDULE_EXACT_ALARM = 214;
+    static final int PERMISSION_CODE_USE_FULL_SCREEN_INTENT = 215;
 
 
     // PERMISSION_GROUP
@@ -62,6 +63,7 @@ final class PermissionConstants {
     static final int PERMISSION_GROUP_CALENDAR_FULL_ACCESS = 37;
     static final int PERMISSION_GROUP_ASSISTANT = 38;
     static final int PERMISSION_GROUP_BACKGROUND_REFRESH = 39;
+    static final int PERMISSION_GROUP_USE_FULL_SCREEN_INTENT = 40;
 
     @Retention(RetentionPolicy.SOURCE)
     @IntDef({
@@ -101,6 +103,8 @@ final class PermissionConstants {
             PERMISSION_GROUP_CALENDAR_WRITE_ONLY,
             PERMISSION_GROUP_CALENDAR_FULL_ACCESS,
             PERMISSION_GROUP_ASSISTANT,
+            PERMISSION_GROUP_BACKGROUND_REFRESH,
+            PERMISSION_GROUP_USE_FULL_SCREEN_INTENT,
     })
     @interface PermissionGroup {
     }

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionManager.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionManager.java
@@ -266,6 +266,16 @@ final class PermissionManager implements PluginRegistry.ActivityResultListener, 
                 requestResults.put(
                     permission,
                     determinePermissionStatus(permission));
+            } else if (permission == PermissionConstants.PERMISSION_GROUP_USE_FULL_SCREEN_INTENT) {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                    NotificationManager notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+                    int status = notificationManager.canUseFullScreenIntent()
+                        ? PermissionConstants.PERMISSION_STATUS_GRANTED
+                        : PermissionConstants.PERMISSION_STATUS_DENIED;
+                    requestResults.put(permission, status);
+                } else {
+                    requestResults.put(permission, PermissionConstants.PERMISSION_STATUS_GRANTED);
+                }
             } else if (!requestResults.containsKey(permission)) {
                 requestResults.put(
                     permission,
@@ -421,6 +431,10 @@ final class PermissionManager implements PluginRegistry.ActivityResultListener, 
                 } else {
                     requestResults.put(permission, PermissionConstants.PERMISSION_STATUS_DENIED);
                 }
+            } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE && permission == PermissionConstants.PERMISSION_GROUP_USE_FULL_SCREEN_INTENT) {
+                launchSpecialPermission(
+                    Settings.ACTION_MANAGE_APP_USE_FULL_SCREEN_INTENT,
+                    PermissionConstants.PERMISSION_CODE_USE_FULL_SCREEN_INTENT);
             } else {
                 permissionsToRequest.addAll(names);
                 pendingRequestCount += names.size();
@@ -565,7 +579,17 @@ final class PermissionManager implements PluginRegistry.ActivityResultListener, 
                     }else {
                         permissionStatuses.add(PermissionUtils.determineDeniedVariant(activity, name));
                     }
-                }else {
+                } else if (permission == PermissionConstants.PERMISSION_GROUP_USE_FULL_SCREEN_INTENT) {
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                        NotificationManager notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+                        int status = notificationManager.canUseFullScreenIntent()
+                            ? PermissionConstants.PERMISSION_STATUS_GRANTED
+                            : PermissionConstants.PERMISSION_STATUS_DENIED;
+                        permissionStatuses.add(status);
+                    } else {
+                        permissionStatuses.add(PermissionConstants.PERMISSION_STATUS_GRANTED);
+                    }
+                } else {
                     final int permissionStatus = ContextCompat.checkSelfPermission(context, name);
                     if (permissionStatus != PackageManager.PERMISSION_GRANTED) {
                         permissionStatuses.add(PermissionUtils.determineDeniedVariant(activity, name));

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionUtils.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionUtils.java
@@ -95,6 +95,8 @@ public class PermissionUtils {
                 return PermissionConstants.PERMISSION_GROUP_AUDIO;
             case Manifest.permission.SCHEDULE_EXACT_ALARM:
                 return PermissionConstants.PERMISSION_GROUP_SCHEDULE_EXACT_ALARM;
+            case Manifest.permission.USE_FULL_SCREEN_INTENT:
+                return PermissionConstants.PERMISSION_GROUP_USE_FULL_SCREEN_INTENT;
             default:
                 return PermissionConstants.PERMISSION_GROUP_UNKNOWN;
         }
@@ -353,6 +355,11 @@ public class PermissionUtils {
                 // The SCHEDULE_EXACT_ALARM permission is introduced in Android S, before Android 31 it should alway return Granted
                 if (hasPermissionInManifest(context, permissionNames, Manifest.permission.SCHEDULE_EXACT_ALARM))
                     permissionNames.add(Manifest.permission.SCHEDULE_EXACT_ALARM);
+                break;
+            case PermissionConstants.PERMISSION_GROUP_USE_FULL_SCREEN_INTENT:
+                // The USE_FULL_SCREEN_INTENT permission is introduced in Android UPSIDE_DOWN_CAKE, before Android 34 it should alway return Granted
+                if (hasPermissionInManifest(context, permissionNames, Manifest.permission.USE_FULL_SCREEN_INTENT))
+                    permissionNames.add(Manifest.permission.USE_FULL_SCREEN_INTENT);
                 break;
             case PermissionConstants.PERMISSION_GROUP_MEDIA_LIBRARY:
             case PermissionConstants.PERMISSION_GROUP_REMINDERS:

--- a/permission_handler_android/example/android/app/src/main/AndroidManifest.xml
+++ b/permission_handler_android/example/android/app/src/main/AndroidManifest.xml
@@ -96,6 +96,8 @@
     <!-- Permissions options for the `alarm` group -->
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
 
+    <!-- Permissions options for the `use full screen intent` group -->
+    <uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT" />
 
     <application
         android:name="${applicationName}"

--- a/permission_handler_android/pubspec.yaml
+++ b/permission_handler_android/pubspec.yaml
@@ -1,7 +1,7 @@
 name: permission_handler_android
 description: Permission plugin for Flutter. This plugin provides the Android API to request and check permissions.
 homepage: https://github.com/baseflow/flutter-permission-handler
-version: 12.0.13
+version: 12.0.14
 
 environment:
   sdk: ">=2.15.0 <4.0.0"

--- a/permission_handler_platform_interface/CHANGELOG.md
+++ b/permission_handler_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.2.4
+
+* Adds support for USE_FULL_SCREEN_INTENT permission check on Android 14+
+
 ## 4.2.3
 
 * Fixes class name references in the API documentation.

--- a/permission_handler_platform_interface/lib/src/permissions.dart
+++ b/permission_handler_platform_interface/lib/src/permissions.dart
@@ -326,6 +326,11 @@ class Permission {
   /// Permission for reading the current background refresh status. (iOS only)
   static const backgroundRefresh = Permission._(39);
 
+  /// Permission for allowing full screen on the device for alarms and calls
+  ///
+  /// Android 14+ (API 34+)
+  static const fullScreen = Permission._(40);
+
   /// Returns a list of all possible [PermissionGroup] values.
   static const List<Permission> values = <Permission>[
     // ignore: deprecated_member_use_from_same_package
@@ -369,6 +374,7 @@ class Permission {
     calendarFullAccess,
     assistant,
     backgroundRefresh,
+    fullScreen,
   ];
 
   static const List<String> _names = <String>[
@@ -412,6 +418,7 @@ class Permission {
     'calendarFullAccess',
     'assistant',
     'backgroundRefresh',
+    'fullScreen',
   ];
 
   @override

--- a/permission_handler_platform_interface/pubspec.yaml
+++ b/permission_handler_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the permission_handler plugin.
 homepage: https://github.com/baseflow/flutter-permission-handler/tree/master/permission_handler_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 4.2.3
+version: 4.2.4
 
 dependencies:
   flutter:

--- a/permission_handler_platform_interface/test/src/permissions_test.dart
+++ b/permission_handler_platform_interface/test/src/permissions_test.dart
@@ -5,7 +5,7 @@ void main() {
   test('Permission has the right amount of possible Permission values', () {
     const values = Permission.values;
 
-    expect(values.length, 40);
+    expect(values.length, 41);
   });
 
   test('check if byValue returns corresponding Permission value', () {


### PR DESCRIPTION
This PR updates permission_handler to handle new requirements for the USE_FULL_SCREEN_INTENT special permission for Android 14+. [Android Documentation](https://source.android.com/docs/core/permissions/fsi-limits)

## Pre-launch Checklist

- [x] I made sure the project builds.
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I rebased onto `main`.
- [x] I added new tests to check the change I am making, or this PR does not need tests.
- [x] I made sure all existing and new tests are passing.
- [x] I ran `dart format .` and committed any changes.
- [x] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
