### PR TITLE
Fixes USE_FULL_SCREEN_INTENT permission request hanging on Android 14+

### DIFF
--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionManager.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionManager.java
@@ -144,6 +144,16 @@ final class PermissionManager implements PluginRegistry.ActivityResultListener, 
             } else {
                 status = PermissionConstants.PERMISSION_STATUS_GRANTED;
             }
+        } else if (requestCode == PermissionConstants.PERMISSION_CODE_USE_FULL_SCREEN_INTENT) {
+            permission = PermissionConstants.PERMISSION_GROUP_USE_FULL_SCREEN_INTENT;
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                NotificationManager notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+                status = notificationManager.canUseFullScreenIntent()
+                    ? PermissionConstants.PERMISSION_STATUS_GRANTED
+                    : PermissionConstants.PERMISSION_STATUS_DENIED;
+            } else {
+                status = PermissionConstants.PERMISSION_STATUS_GRANTED;
+            }
         } else {
             return false;
         }


### PR DESCRIPTION
### Description

This PR fixes a critical bug where requesting the `USE_FULL_SCREEN_INTENT` permission on Android 14+ (API 34+) causes the permission manager to become stuck in a pending state, blocking all subsequent permission requests with the error: "A request for permissions is already running, please wait for it to finish before doing another request".

### Root Cause

The issue was caused by a missing case in the `onActivityResult` method for handling the `PERMISSION_CODE_USE_FULL_SCREEN_INTENT` request code. While the permission request was correctly launched via `launchSpecialPermission()` and `pendingRequestCount` was incremented, the result was never processed when the user returned from the system settings page, leaving the permission manager in a perpetually pending state.

### Changes Made

- Added missing case in `onActivityResult`: Added handling for `PERMISSION_CODE_USE_FULL_SCREEN_INTENT` in the `PermissionManager.onActivityResult()` method
- Proper status checking: Uses `NotificationManager.canUseFullScreenIntent()` to determine the actual permission status on Android 14+
